### PR TITLE
Add support for custom ingressClassName in Ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The following table lists the configurable parameters of the apollo-service char
 | `configService.ingress.hosts.host` | The host of the ingress for config-service | `nil` |
 | `configService.ingress.hosts.paths` | The paths of the ingress for config-service | `[]` |
 | `configService.ingress.tls` | The tls definition of the ingress for config-service | `[]` |
+| `configService.ingress.ingressClassName` | The ingressClassName definition of the ingress for config-service | `nil` |
 | `configService.liveness.initialDelaySeconds` | The initial delay seconds of liveness probe | `100` |
 | `configService.liveness.periodSeconds` | The period seconds of liveness probe | `10` |
 | `configService.readiness.initialDelaySeconds` | The initial delay seconds of readiness probe | `30` |
@@ -112,6 +113,7 @@ The following table lists the configurable parameters of the apollo-service char
 | `adminService.ingress.hosts.host` | The host of the ingress for admin-service | `nil` |
 | `adminService.ingress.hosts.paths` | The paths of the ingress for admin-service | `[]` |
 | `adminService.ingress.tls` | The tls definition of the ingress for admin-service | `[]` |
+| `adminService.ingress.ingressClassName` | The ingressClassName definition of the ingress for admin-service | `nil` |
 | `adminService.liveness.initialDelaySeconds` | The initial delay seconds of liveness probe | `100` |
 | `adminService.liveness.periodSeconds` | The period seconds of liveness probe | `10` |
 | `adminService.readiness.initialDelaySeconds` | The initial delay seconds of readiness probe | `30` |
@@ -249,6 +251,7 @@ The following table lists the configurable parameters of the apollo-portal chart
 | `ingress.hosts.host` | The host of the ingress | `nil` |
 | `ingress.hosts.paths` | The paths of the ingress | `[]` |
 | `ingress.tls` | The tls definition of the ingress | `[]` |
+| `ingress.ingressClassName` | The ingressClassName definition of the ingress | `nil` |
 | `liveness.initialDelaySeconds` | The initial delay seconds of liveness probe | `100` |
 | `liveness.periodSeconds` | The period seconds of liveness probe | `10` |
 | `readiness.initialDelaySeconds` | The initial delay seconds of readiness probe | `30` |

--- a/apollo-portal/templates/ingress-portal.yaml
+++ b/apollo-portal/templates/ingress-portal.yaml
@@ -33,6 +33,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/apollo-portal/values.yaml
+++ b/apollo-portal/values.yaml
@@ -29,6 +29,7 @@ service:
   type: ClusterIP
   sessionAffinity: ClientIP
 ingress:
+  ingressClassName: null
   enabled: false
   annotations: {}
   hosts:

--- a/apollo-service/templates/ingress-adminservice.yaml
+++ b/apollo-service/templates/ingress-adminservice.yaml
@@ -33,6 +33,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.adminService.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.adminService.ingress.ingressClassName }}
+{{- end }}
 {{- if .Values.adminService.ingress.tls }}
   tls:
   {{- range .Values.adminService.ingress.tls }}

--- a/apollo-service/templates/ingress-configservice.yaml
+++ b/apollo-service/templates/ingress-configservice.yaml
@@ -33,6 +33,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.configService.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.configService.ingress.ingressClassName }}
+{{- end }}
 {{- if .Values.configService.ingress.tls }}
   tls:
   {{- range .Values.configService.ingress.tls }}

--- a/apollo-service/values.yaml
+++ b/apollo-service/values.yaml
@@ -47,6 +47,7 @@ configService:
     targetPort: 8080
     type: ClusterIP
   ingress:
+    ingressClassName: null
     enabled: false
     annotations: { }
     hosts:
@@ -92,6 +93,7 @@ adminService:
     targetPort: 8090
     type: ClusterIP
   ingress:
+    ingressClassName: null
     enabled: false
     annotations: { }
     hosts:


### PR DESCRIPTION
This change adds the ability to specify a custom ingressClassName when creating an Ingress resource. This is useful when using AWS EKS with an Application Load Balancer (ALB), as the ingressClassName needs to be set to "alb" in order to work correctly. This change allows users to set a different ingressClassName if needed, while still supporting the "alb" value for those using AWS EKS with ALB.

I hope this helps!