### PR TITLE
Add support for NodePort in Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The following table lists the configurable parameters of the apollo-service char
 | `configService.service.fullNameOverride` | Override the service name for apollo-configservice | `nil` |
 | `configService.service.port` | The port for the service of apollo-configservice | `8080` |
 | `configService.service.targetPort` | The target port for the service of apollo-configservice | `8080` |
+| `configService.service.nodePort` | The node port for the service of apollo-configservice | `8080` |
 | `configService.service.type` | The service type of apollo-configservice                     | `ClusterIP` |
 | `configService.ingress.enabled` | Whether to enable the ingress for config-service or not | `false` |
 | `configService.ingress.annotations` | The annotations of the ingress for config-service | `{}` |
@@ -107,6 +108,7 @@ The following table lists the configurable parameters of the apollo-service char
 | `adminService.service.fullNameOverride` | Override the service name for apollo-adminservice | `nil` |
 | `adminService.service.port` | The port for the service of apollo-adminservice | `8090` |
 | `adminService.service.targetPort` | The target port for the service of apollo-adminservice | `8090` |
+| `adminService.service.nodePort` | The node port for the service of apollo-adminservice | `nil` |
 | `adminService.service.type` | The service type of apollo-adminservice                     | `ClusterIP` |
 | `adminService.ingress.enabled` | Whether to enable the ingress for admin-service or not | `false` |
 | `adminService.ingress.annotations` | The annotations of the ingress for admin-service | `{}` |
@@ -244,6 +246,7 @@ The following table lists the configurable parameters of the apollo-portal chart
 | `service.fullNameOverride` | Override the service name for apollo-portal | `nil` |
 | `service.port` | The port for the service of apollo-portal | `8070` |
 | `service.targetPort` | The target port for the service of apollo-portal | `8070` |
+| `service.nodePort` | The node port for the service of apollo-portal | `nil` |
 | `service.type` | The service type of apollo-portal                     | `ClusterIP` |
 | `service.sessionAffinity` | The session affinity for the service of apollo-portal | `ClientIP` |
 | `ingress.enabled` | Whether to enable the ingress or not | `false` |

--- a/apollo-portal/templates/service-portal.yaml
+++ b/apollo-portal/templates/service-portal.yaml
@@ -26,6 +26,11 @@ spec:
       protocol: TCP
       port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) .Values.service.nodePort}}
+      nodePort: {{ .Values.service.nodePort}}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
   selector:
     app: {{ include "apollo.portal.fullName" . }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}

--- a/apollo-portal/values.yaml
+++ b/apollo-portal/values.yaml
@@ -26,6 +26,7 @@ service:
   fullNameOverride: ""
   port: 8070
   targetPort: 8070
+  nodePort: ""
   type: ClusterIP
   sessionAffinity: ClientIP
 ingress:

--- a/apollo-service/templates/service-adminservice.yaml
+++ b/apollo-service/templates/service-adminservice.yaml
@@ -26,5 +26,10 @@ spec:
       protocol: TCP
       port: {{ .Values.adminService.service.port }}
       targetPort: {{ .Values.adminService.service.targetPort }}
+      {{- if and (or (eq .Values.adminService.service.type "NodePort") (eq .Values.adminService.service.type "LoadBalancer")) .Values.adminService.service.nodePort}}
+      nodePort: {{ .Values.adminService.service.nodePort}}
+      {{- else if eq .Values.adminService.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
   selector:
     app: {{ include "apollo.adminService.fullName" . }}

--- a/apollo-service/templates/service-configservice.yaml
+++ b/apollo-service/templates/service-configservice.yaml
@@ -26,5 +26,10 @@ spec:
       protocol: TCP
       port: {{ .Values.configService.service.port }}
       targetPort: {{ .Values.configService.service.targetPort }}
+      {{- if and (or (eq .Values.configService.service.type "NodePort") (eq .Values.configService.service.type "LoadBalancer")) .Values.configService.service.nodePort}}
+      nodePort: {{ .Values.configService.service.nodePort}}
+      {{- else if eq .Values.configService.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
   selector:
     app: {{ include "apollo.configService.fullName" . }}

--- a/apollo-service/values.yaml
+++ b/apollo-service/values.yaml
@@ -45,6 +45,7 @@ configService:
     fullNameOverride: ""
     port: 8080
     targetPort: 8080
+    nodePort: ""
     type: ClusterIP
   ingress:
     ingressClassName: null
@@ -91,6 +92,7 @@ adminService:
     fullNameOverride: ""
     port: 8090
     targetPort: 8090
+    nodePort: ""
     type: ClusterIP
   ingress:
     ingressClassName: null


### PR DESCRIPTION
Add support for Service NodePort configuration, so that NodePort can be manually configured when Service Type is set to NodePort or LoadBalancer.

Issue #10 