### PR TITLE
Add support for annotations for portal/admin service/config service d…

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The following table lists the configurable parameters of the apollo-service char
 | `configService.nodeSelector` | The node selector definition of apollo-configservice | `{}` |
 | `configService.tolerations` | The tolerations definition of apollo-configservice | `[]` |
 | `configService.affinity` | The affinity definition of apollo-configservice | `{}` |
+| `configService.annotations` | The annotations definition of apollo-configservice | `{}` |
 | `adminService.fullNameOverride` | Override the deployment name for apollo-adminservice | `nil` |
 | `adminService.replicaCount` | Replica count of apollo-adminservice | `2` |
 | `adminService.containerPort` | Container port of apollo-adminservice | `8090` |
@@ -126,6 +127,7 @@ The following table lists the configurable parameters of the apollo-service char
 | `adminService.nodeSelector` | The node selector definition of apollo-adminservice | `{}` |
 | `adminService.tolerations` | The tolerations definition of apollo-adminservice | `[]` |
 | `adminService.affinity` | The affinity definition of apollo-adminservice | `{}` |
+| `adminService.annotations` | The annotations definition of apollo-adminservice | `{}` |
 
 ### 4.4 Sample
 
@@ -262,6 +264,7 @@ The following table lists the configurable parameters of the apollo-portal chart
 | `nodeSelector` | The node selector definition of apollo-portal | `{}` |
 | `tolerations` | The tolerations definition of apollo-portal | `[]` |
 | `affinity` | The affinity definition of apollo-portal | `{}` |
+| `annotations` | The annotations definition of apollo-portal | `{}` |
 | `config.profiles` | specify the spring profiles to activate | `github,auth` |
 | `config.envs` | specify the env names, e.g. dev,pro | `nil` |
 | `config.contextPath` | specify the context path, e.g. `/apollo`, then users could access portal via `http://{portal_address}/apollo` | `nil` |

--- a/apollo-portal/templates/deployment-portal.yaml
+++ b/apollo-portal/templates/deployment-portal.yaml
@@ -60,8 +60,10 @@ spec:
     metadata:
       labels:
         app: {{ $portalFullName }}
+      {{- with .Values.annotations }}
       annotations:
-        {{- toYaml .Values.annotations| nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/apollo-portal/templates/deployment-portal.yaml
+++ b/apollo-portal/templates/deployment-portal.yaml
@@ -60,6 +60,8 @@ spec:
     metadata:
       labels:
         app: {{ $portalFullName }}
+      annotations:
+        {{- toYaml .Values.annotations| nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/apollo-portal/values.yaml
+++ b/apollo-portal/values.yaml
@@ -49,6 +49,7 @@ resources: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+annotations: {}
 
 config:
   # spring profiles to activate

--- a/apollo-service/templates/deployment-adminservice.yaml
+++ b/apollo-service/templates/deployment-adminservice.yaml
@@ -49,8 +49,10 @@ spec:
     metadata:
       labels:
         app: {{ $adminServiceFullName }}
+      {{- with .Values.annotations }}
       annotations:
-        {{- toYaml .Values.adminService.annotations| nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.adminService.imagePullSecrets }}
       imagePullSecrets:

--- a/apollo-service/templates/deployment-adminservice.yaml
+++ b/apollo-service/templates/deployment-adminservice.yaml
@@ -49,7 +49,7 @@ spec:
     metadata:
       labels:
         app: {{ $adminServiceFullName }}
-      {{- with .Values.annotations }}
+      {{- with .Values.adminService.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/apollo-service/templates/deployment-adminservice.yaml
+++ b/apollo-service/templates/deployment-adminservice.yaml
@@ -49,6 +49,8 @@ spec:
     metadata:
       labels:
         app: {{ $adminServiceFullName }}
+      annotations:
+        {{- toYaml .Values.adminService.annotations| nindent 8 }}
     spec:
       {{- with .Values.adminService.imagePullSecrets }}
       imagePullSecrets:

--- a/apollo-service/templates/deployment-configservice.yaml
+++ b/apollo-service/templates/deployment-configservice.yaml
@@ -51,6 +51,8 @@ spec:
     metadata:
       labels:
         app: {{ $configServiceFullName }}
+      annotations:
+        {{- toYaml .Values.configService.annotations| nindent 8 }}
     spec:
       {{- with .Values.configService.imagePullSecrets }}
       imagePullSecrets:

--- a/apollo-service/templates/deployment-configservice.yaml
+++ b/apollo-service/templates/deployment-configservice.yaml
@@ -51,8 +51,10 @@ spec:
     metadata:
       labels:
         app: {{ $configServiceFullName }}
+      {{- with .Values.annotations }}
       annotations:
-        {{- toYaml .Values.configService.annotations| nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.configService.imagePullSecrets }}
       imagePullSecrets:

--- a/apollo-service/templates/deployment-configservice.yaml
+++ b/apollo-service/templates/deployment-configservice.yaml
@@ -51,7 +51,7 @@ spec:
     metadata:
       labels:
         app: {{ $configServiceFullName }}
-      {{- with .Values.annotations }}
+      {{- with .Values.configService.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/apollo-service/values.yaml
+++ b/apollo-service/values.yaml
@@ -76,6 +76,7 @@ configService:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  annotations: {}
 
 adminService:
   name: apollo-adminservice
@@ -118,3 +119,4 @@ adminService:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  annotations: {}


### PR DESCRIPTION
add support for setting annotations for deployment, so that we could use characteristic in cloud PaaS Kubernetes, like [AliCloud Spot](https://help.aliyun.com/document_detail/165053.html?spm=a2c4g.164459.0.0.76b63241hc4UqG)